### PR TITLE
Code & comment reformatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # generic-field-projection
 
-This is a general purpose projection library that doesn't special case any pointer type except for
-raw pointers. This makes the UX for all smart pointers the same, and more consistent.
+This is a general purpose projection library that doesn't special case any
+pointer type except for raw pointers. This makes the UX for all smart pointers
+the same, and more consistent.
 
-This workspace is a proof of concept for the pointer to field concept discussed in this [Rust Internals](https://internals.rust-lang.org/t/idea-pointer-to-field/10061) discussion, and the [RFC](https://github.com/rust-lang/rfcs/pull/2708).
+This workspace is a proof of concept for the pointer to field concept discussed
+in this [Rust
+Internals](https://internals.rust-lang.org/t/idea-pointer-to-field/10061)
+discussion, and the [RFC](https://github.com/rust-lang/rfcs/pull/2708).
 
-Disclaimer: This workspace does not intend to be a fully fledged implementation, and will likely be missing many key features to making the pointer to field idea truly work.
+Disclaimer: This workspace does not intend to be a fully fledged implementation,
+and will likely be missing many key features to making the pointer to field idea
+truly work.
 
-Basic sketch of how this workspace workspace
+Basic sketch of how this workspace works:
 
 ```rust
 #[derive(Field)]     // This derive is given in the ptr-to-field-macro crate
@@ -18,7 +24,7 @@ struct Foo {
 }
 ```
 
-It will give the following implementations
+It will give the following implementations:
 
 ```rust
 pub mod Foo_fields {

--- a/core/src/chain.rs
+++ b/core/src/chain.rs
@@ -4,7 +4,7 @@ use super::*;
 #[derive(Clone, Copy)]
 pub struct Chain<A, B> {
     a: A,
-    b: B
+    b: B,
 }
 
 impl<A, B> Chain<A, B> {

--- a/core/src/chain.rs
+++ b/core/src/chain.rs
@@ -23,13 +23,13 @@ unsafe impl<A: Field, B: Field<Parent = A::Type>> Field for Chain<A, B> {
     fn name(&self) -> Self::Name {
         self.a.name().chain(self.b.name())
     }
-    
+
     #[inline]
     unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
         let ptr = self.a.project_raw(ptr);
         self.b.project_raw(ptr)
     }
-    
+
     #[inline]
     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type {
         let ptr = self.a.project_raw_mut(ptr);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,15 +7,15 @@ This crate provides a generic interface to project to fields, think of it as an
 extended version of `Deref` that handles all pointer types equally.
 */
 
-mod project;
-mod pin;
+mod chain;
 #[doc(hidden)]
 pub mod macros;
-mod chain;
+mod pin;
+mod project;
 mod set;
 
-pub use self::pin::*;
 pub use self::chain::*;
+pub use self::pin::*;
 pub use self::set::FieldSet;
 pub use gfp_derive::Field;
 
@@ -23,15 +23,19 @@ pub(crate) use self::set::tuple::*;
 
 #[doc(hidden)]
 pub mod derive {
+    pub use core::iter::{once, Once};
     pub use core::marker::PhantomData;
-    pub use core::iter::{Once, once};
 
     pub struct Invariant<T: ?Sized>(pub PhantomData<*mut T>);
 
     unsafe impl<T: ?Sized> Send for Invariant<T> {}
     unsafe impl<T: ?Sized> Sync for Invariant<T> {}
 
-    impl<T: ?Sized> Clone for Invariant<T> { fn clone(&self) -> Self { *self } }
+    impl<T: ?Sized> Clone for Invariant<T> {
+        fn clone(&self) -> Self {
+            *self
+        }
+    }
     impl<T: ?Sized> Copy for Invariant<T> {}
 }
 
@@ -207,7 +211,10 @@ pub unsafe trait Field {
     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type;
 
     /// Chains the projection of this field with another field `F`
-    fn chain<F: Field<Parent = Self::Type>>(self, f: F) -> Chain<Self, F> where Self: Sized {
+    fn chain<F: Field<Parent = Self::Type>>(self, f: F) -> Chain<Self, F>
+    where
+        Self: Sized,
+    {
         Chain::new(self, f)
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,8 +3,8 @@
 #![no_std]
 
 /*!
-This crate provides a generic interface to project to fields, think of it as an extended version
-of `Deref` that handles all pointer types equally.
+This crate provides a generic interface to project to fields, think of it as an
+extended version of `Deref` that handles all pointer types equally.
 */
 
 mod project;
@@ -30,7 +30,7 @@ pub mod derive {
 
     unsafe impl<T: ?Sized> Send for Invariant<T> {}
     unsafe impl<T: ?Sized> Sync for Invariant<T> {}
-    
+
     impl<T: ?Sized> Clone for Invariant<T> { fn clone(&self) -> Self { *self } }
     impl<T: ?Sized> Copy for Invariant<T> {}
 }
@@ -55,11 +55,11 @@ pub trait ProjectToSet<F: FieldSet> {
 
 /// Represents a field of some `Parent` type
 /// You can derive this trait for all fields of `Parent` by using
-/// 
+///
 /// ```rust
 /// # mod __ {
 /// use gfp_core::Field;
-/// 
+///
 /// #[derive(Field)]
 /// struct Foo {
 ///     bar: u32,
@@ -67,102 +67,104 @@ pub trait ProjectToSet<F: FieldSet> {
 /// }
 /// # }
 /// ```
-/// 
+///
 /// # Safety
-/// 
+///
 /// * `Parent` must represent the type where the field came from
 /// * `Type` must represent the type of the field itself
 /// * `project_raw` and `project_raw_mut` must only access the given field
-/// * `name` must return an iterator that yields all of the fields from `Parent` to the given field,
-/// 
+/// * `name` must return an iterator that yields all of the fields from `Parent`
+///   to the given field,
+///
 /// ex.
-/// 
+///
 /// ```rust
 /// struct Foo {
 ///     bar: Bar
 /// }
-/// 
+///
 /// struct Bar {
 ///     tap: Tap
 /// }
-/// 
+///
 /// struct Tap {
 ///     val: u32
 /// }
 /// ```
-/// 
+///
 /// if want to get field `val` from `Foo`,
-/// 
+///
 /// you must implement field like so,
-/// 
+///
 /// ```rust
 /// # struct Foo {
 /// #     bar: Bar
 /// # }
-/// # 
+/// #
 /// # struct Bar {
 /// #     tap: Tap
 /// # }
-/// # 
+/// #
 /// # struct Tap {
 /// #     val: u32
 /// # }
 /// use gfp_core::Field;
-/// 
+///
 /// struct FieldVal;
-/// 
+///
 /// unsafe impl Field for FieldVal {
 ///     type Parent = Foo;
 ///     type Type = u32;
 ///     type Name = std::iter::Copied<std::slice::Iter<'static, &'static str>>;
-///     
+///
 ///     fn name(&self) -> Self::Name {
 ///         ["bar", "tap", "val"].iter().copied()
 ///     }
-///     
+///
 ///     unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
 ///         &(*ptr).bar.tap.val
 ///     }
-///     
+///
 ///     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type {
 ///         &mut (*ptr).bar.tap.val
 ///     }
 /// }
 /// ```
-/// 
-/// But it is better to just derive `Field` on the types that you need to, and then use the [`chain`](trait.Fields.html#method.chain)
-/// combinator to project to the fields of fields
-/// 
+///
+/// But it is better to just derive `Field` on the types that you need to, and
+/// then use the [`chain`](trait.Fields.html#method.chain) combinator to project
+/// to the fields of fields
+///
 /// ```rust
 /// # mod main {
 /// use gfp_core::Field;
-/// 
+///
 /// #[derive(Field)]
 /// struct Foo {
 ///     bar: Bar
 /// }
-/// 
+///
 /// #[derive(Field)]
 /// struct Bar {
 ///     tap: Tap
 /// }
-/// 
+///
 /// #[derive(Field)]
 /// struct Tap {
 ///     val: u32
 /// }
-/// 
+///
 /// fn main() {
 ///     let foo_to_val = Foo::fields().bar.chain(
 ///         Bar::fields().tap
 ///     ).chain(
 ///         Tap::fields().val
 ///     );
-/// 
+///
 ///     // or if you are going to use that projection a lot
-///     
+///
 ///     use gfp_core::Chain;
-///     
+///
 ///     const FOO_TO_VAL: Chain<Chain<Foo_fields::bar::<Foo>, Bar_fields::tap::<Bar>>, Tap_fields::val::<Tap>> = Chain::new(
 ///         Chain::new(
 ///             Foo::FIELDS.bar,
@@ -173,7 +175,7 @@ pub trait ProjectToSet<F: FieldSet> {
 /// }
 /// # }
 /// ```
-/// 
+///
 pub unsafe trait Field {
     /// The type that the field comes from
     type Parent: ?Sized;
@@ -185,22 +187,22 @@ pub unsafe trait Field {
     type Name: Iterator<Item = &'static str>;
 
     /// An iterator that returns the fully qualified name of the field
-    /// 
+    ///
     /// This must be unique for each field of the given `Parent` type
     fn name(&self) -> Self::Name;
 
     /// projects the raw pointer from the `Parent` type to the field `Type`
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// * `ptr` must point to a valid, initialized allocation of `Parent`
     /// * the projection is not safe to write to
     unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type;
-    
+
     /// projects the raw pointer from the `Parent` type to the field `Type`
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// `ptr` must point to a valid, initialized allocation of `Parent`
     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type;
 
@@ -219,12 +221,12 @@ unsafe impl<F: ?Sized + Field> Field for &F {
     fn name(&self) -> Self::Name {
         F::name(self)
     }
-    
+
     #[inline]
     unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
         F::project_raw(self, ptr)
     }
-    
+
     #[inline]
     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type {
         F::project_raw_mut(self, ptr)
@@ -240,12 +242,12 @@ unsafe impl<F: ?Sized + Field> Field for &mut F {
     fn name(&self) -> Self::Name {
         F::name(self)
     }
- 
-    #[inline]   
+
+    #[inline]
     unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
         F::project_raw(self, ptr)
     }
-    
+
     #[inline]
     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type {
         F::project_raw_mut(self, ptr)

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -39,7 +39,7 @@ macro_rules! field {
             type Parent = $parent;
             type Type = $field_ty;
             type Name = $crate::macros::Once<&'static str>;
-    
+
             fn name(&self) -> Self::Name {
                 $crate::macros::once(stringify!($field))
             }
@@ -48,7 +48,7 @@ macro_rules! field {
             unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
                 &(*ptr).$field
             }
-            
+
             #[inline]
             unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type {
                 &mut (*ptr).$field

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -1,5 +1,4 @@
-
-pub use core::iter::{Once, once};
+pub use core::iter::{once, Once};
 
 /// Create a new field descriptor for the given type
 #[macro_export]
@@ -8,9 +7,7 @@ macro_rules! field_descriptor {
         let mut value = $value;
         let parent: *mut _ = &mut value;
         let field: *mut _ = &mut value.$field;
-        unsafe {
-            $crate::FieldDescriptor::from_pointers(parent, field)
-        }
+        unsafe { $crate::FieldDescriptor::from_pointers(parent, field) }
     }};
 }
 

--- a/core/src/pin.rs
+++ b/core/src/pin.rs
@@ -1,9 +1,9 @@
 use super::*;
 
 /// A marker trait that specifies pointer safely project inside of a pin
-/// 
+///
 /// # Safety
-/// 
+///
 /// TODO: add safety docs
 pub unsafe trait PinnablePointer: core::ops::Deref {}
 
@@ -27,12 +27,12 @@ unsafe impl<F: ?Sized + Field> Field for PinToPin<F> {
     fn name(&self) -> Self::Name {
         F::name(&self.field)
     }
-    
+
     #[inline]
     unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
         F::project_raw(&self.field, ptr)
     }
-    
+
     #[inline]
     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type {
         F::project_raw_mut(&self.field, ptr)
@@ -48,12 +48,12 @@ unsafe impl<F: ?Sized + Field> Field for PinToPtr<F> {
     fn name(&self) -> Self::Name {
         F::name(&self.0)
     }
-    
+
     #[inline]
     unsafe fn project_raw(&self, ptr: *const Self::Parent) -> *const Self::Type {
         F::project_raw(&self.0, ptr)
     }
-    
+
     #[inline]
     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> *mut Self::Type {
         F::project_raw_mut(&self.0, ptr)
@@ -68,7 +68,7 @@ impl<F: Field> PinToPin<F> {
             field
         }
     }
-    
+
     /// Convert to a dynamically dispatched field projection
     #[inline]
     pub fn as_dyn_pin(&self) -> PinToPin<&dyn Field<Parent = F::Parent, Type = F::Type, Name = F::Name>> {
@@ -76,7 +76,7 @@ impl<F: Field> PinToPin<F> {
             field: &self.field
         }
     }
-    
+
     #[inline]
     pub(crate) fn field(self) -> F {
         self.field
@@ -105,7 +105,7 @@ impl<F: Field> PinToPtr<F> {
     pub fn new(field: F) -> Self {
         Self(field)
     }
-    
+
     /// Convert to a dynamically dispatched field projection
     #[inline]
     pub fn as_dyn_pin(&self) -> PinToPtr<&dyn Field<Parent = F::Parent, Type = F::Type, Name = F::Name>> {

--- a/core/src/pin.rs
+++ b/core/src/pin.rs
@@ -15,7 +15,7 @@ pub struct PinToPtr<F: Field + ?Sized>(pub F);
 #[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct PinToPin<F: Field + ?Sized> {
-    field: F
+    field: F,
 }
 
 unsafe impl<F: ?Sized + Field> Field for PinToPin<F> {
@@ -64,17 +64,15 @@ impl<F: Field> PinToPin<F> {
     /// You must validate the safety notes of [`PinProjectable<F>`](trait.PinProjectable.html)
     #[inline]
     pub unsafe fn new_unchecked(field: F) -> Self {
-        Self {
-            field
-        }
+        Self { field }
     }
 
     /// Convert to a dynamically dispatched field projection
     #[inline]
-    pub fn as_dyn_pin(&self) -> PinToPin<&dyn Field<Parent = F::Parent, Type = F::Type, Name = F::Name>> {
-        PinToPin {
-            field: &self.field
-        }
+    pub fn as_dyn_pin(
+        &self,
+    ) -> PinToPin<&dyn Field<Parent = F::Parent, Type = F::Type, Name = F::Name>> {
+        PinToPin { field: &self.field }
     }
 
     #[inline]
@@ -93,9 +91,7 @@ impl<F: Field + ?Sized> PinToPin<F> {
 
     #[inline]
     pub fn as_ref(&self) -> PinToPin<&F> {
-        unsafe {
-            PinToPin::new_unchecked(&self.field)
-        }
+        unsafe { PinToPin::new_unchecked(&self.field) }
     }
 }
 
@@ -108,7 +104,9 @@ impl<F: Field> PinToPtr<F> {
 
     /// Convert to a dynamically dispatched field projection
     #[inline]
-    pub fn as_dyn_pin(&self) -> PinToPtr<&dyn Field<Parent = F::Parent, Type = F::Type, Name = F::Name>> {
+    pub fn as_dyn_pin(
+        &self,
+    ) -> PinToPtr<&dyn Field<Parent = F::Parent, Type = F::Type, Name = F::Name>> {
         PinToPtr(&self.0)
     }
 }

--- a/core/src/project.rs
+++ b/core/src/project.rs
@@ -1,11 +1,11 @@
 use super::*;
 
-mod from_pin;
 mod from_mut;
+mod from_pin;
 mod from_ref;
 
-use core::pin::Pin;
-use core::ops::Deref;
 use core::marker::PhantomData;
+use core::ops::Deref;
+use core::pin::Pin;
 
 use crate::pin::*;

--- a/core/src/project/from_mut.rs
+++ b/core/src/project/from_mut.rs
@@ -49,7 +49,7 @@ type_function! {
             field: input
         })
     }
-    
+
     for(I: Field, J: Field)
     fn(self: FindOverlapInner<I>, input: J) -> bool {
         self.counter += 1;
@@ -66,7 +66,7 @@ type_function! {
 impl<'a, F: FieldSet> ProjectToSet<F> for &'a mut F::Parent
 where F::Parent: 'a,
       F::TypeSetMut: TupleMap<PtrToRefMut<'a>>,
-      
+
       F: Copy + TupleAny<FindOverlap<F>> {
     type Projection = TMap<F::TypeSetMut, PtrToRefMut<'a>>;
 

--- a/core/src/project/from_mut.rs
+++ b/core/src/project/from_mut.rs
@@ -18,25 +18,26 @@ type_function! {
 
 unsafe impl<F: ?Sized> PinnablePointer for &mut F {}
 impl<'a, F: Field> ProjectTo<F> for &'a mut F::Parent
-where F::Parent: 'a, F::Type: 'a {
+where
+    F::Parent: 'a,
+    F::Type: 'a,
+{
     type Projection = &'a mut F::Type;
 
     fn project_to(self, field: F) -> Self::Projection {
-        unsafe {
-            &mut *field.project_raw_mut(self)
-        }
+        unsafe { &mut *field.project_raw_mut(self) }
     }
 }
 
 pub struct FindOverlap<S> {
     counter: u64,
-    set: S
+    set: S,
 }
 
 pub struct FindOverlapInner<I> {
     id: u64,
     counter: u64,
-    field: I
+    field: I,
 }
 
 type_function! {
@@ -64,19 +65,21 @@ type_function! {
 }
 
 impl<'a, F: FieldSet> ProjectToSet<F> for &'a mut F::Parent
-where F::Parent: 'a,
-      F::TypeSetMut: TupleMap<PtrToRefMut<'a>>,
+where
+    F::Parent: 'a,
+    F::TypeSetMut: TupleMap<PtrToRefMut<'a>>,
 
-      F: Copy + TupleAny<FindOverlap<F>> {
+    F: Copy + TupleAny<FindOverlap<F>>,
+{
     type Projection = TMap<F::TypeSetMut, PtrToRefMut<'a>>;
 
     #[inline]
     fn project_set_to(self, field: F) -> Self::Projection {
         unsafe {
             if field.tup_any(FindOverlap {
-                    counter: 0,
-                    set: field
-                }) {
+                counter: 0,
+                set: field,
+            }) {
                 panic!("Found overlapping fields")
             } else {
                 let type_set = field.project_raw_mut(self);

--- a/core/src/project/from_pin.rs
+++ b/core/src/project/from_pin.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 impl<'a, F: Field, P: PinnablePointer + ProjectTo<F>> ProjectTo<PinToPin<F>> for Pin<P>
-where P::Projection: core::ops::Deref<Target = F::Type> {
+where
+    P::Projection: core::ops::Deref<Target = F::Type>,
+{
     type Projection = Pin<P::Projection>;
 
     fn project_to(self, pin_field: PinToPin<F>) -> Self::Projection {
@@ -45,7 +47,7 @@ type_function! {
 impl<F: Copy + FieldSet, P: ProjectToSet<F> + Deref> ProjectToSet<F> for Pin<P>
 where
     F: TupleMap<CreateTag>,
-    TMap<F, CreateTag>: TupleZip<P::Projection, BuildOutput>
+    TMap<F, CreateTag>: TupleZip<P::Projection, BuildOutput>,
 {
     type Projection = TZip<TMap<F, CreateTag>, P::Projection, BuildOutput>;
 
@@ -53,8 +55,7 @@ where
     fn project_set_to(self, field: F) -> Self::Projection {
         let tags = field.tup_map(CreateTag);
         unsafe {
-            let raw_output = Pin::into_inner_unchecked(self)
-                .project_set_to(field);
+            let raw_output = Pin::into_inner_unchecked(self).project_set_to(field);
 
             tags.tup_zip(raw_output, BuildOutput)
         }

--- a/core/src/project/from_pin.rs
+++ b/core/src/project/from_pin.rs
@@ -55,7 +55,7 @@ where
         unsafe {
             let raw_output = Pin::into_inner_unchecked(self)
                 .project_set_to(field);
-            
+
             tags.tup_zip(raw_output, BuildOutput)
         }
     }

--- a/core/src/project/from_ref.rs
+++ b/core/src/project/from_ref.rs
@@ -1,4 +1,3 @@
-
 use super::*;
 
 pub struct PtrToRef<'a>(PhantomData<&'a ()>);
@@ -12,19 +11,22 @@ type_function! {
 
 unsafe impl<F: ?Sized> PinnablePointer for &F {}
 impl<'a, F: Field> ProjectTo<F> for &'a F::Parent
-where F::Parent: 'a, F::Type: 'a {
+where
+    F::Parent: 'a,
+    F::Type: 'a,
+{
     type Projection = &'a F::Type;
 
     fn project_to(self, field: F) -> Self::Projection {
-        unsafe {
-            &*field.project_raw(self)
-        }
+        unsafe { &*field.project_raw(self) }
     }
 }
 
 impl<'a, F: FieldSet> ProjectToSet<F> for &'a F::Parent
-where F::Parent: 'a,
-      F::TypeSet: TupleMap<PtrToRef<'a>> {
+where
+    F::Parent: 'a,
+    F::TypeSet: TupleMap<PtrToRef<'a>>,
+{
     type Projection = TMap<F::TypeSet, PtrToRef<'a>>;
 
     #[inline]

--- a/core/src/set.rs
+++ b/core/src/set.rs
@@ -15,17 +15,17 @@ pub unsafe trait FieldSet: Tuple {
     type TypeSetMut: Tuple;
 
     /// projects the raw pointer from the `Parent` type to the field `Type`
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// * `ptr` must point to a valid, initialized allocation of `Parent`
     /// * the projection is not safe to write to
     unsafe fn project_raw(&self, ptr: *const Self::Parent) -> Self::TypeSet;
-    
+
     /// projects the raw pointer from the `Parent` type to the field `Type`
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// * `ptr` must point to a valid, initialized allocation of `Parent`
     /// * the projection is not safe to write to
     unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> Self::TypeSetMut;
@@ -35,13 +35,13 @@ macro_rules! impl_tuple {
     () => {};
     ($first:ident $($T:ident)*) => {
         impl_tuple! { $($T)* }
-                
+
         unsafe impl<$first: Field, $($T: Field<Parent = $first::Parent>),*> FieldSet for ($first, $($T),*) {
             type Parent = $first::Parent;
-            
+
             type TypeSet = (*const $first::Type, $(*const $T::Type),*);
             type TypeSetMut = (*mut $first::Type, $(*mut $T::Type),*);
-            
+
             #[inline]
             #[allow(non_snake_case)]
             unsafe fn project_raw(&self, ptr: *const Self::Parent) -> Self::TypeSet {
@@ -51,7 +51,7 @@ macro_rules! impl_tuple {
                     $($T.project_raw(ptr)),*
                 )
             }
-            
+
             #[inline]
             #[allow(non_snake_case)]
             unsafe fn project_raw_mut(&self, ptr: *mut Self::Parent) -> Self::TypeSetMut {

--- a/core/src/set/tuple.rs
+++ b/core/src/set/tuple.rs
@@ -55,7 +55,7 @@ macro_rules! impl_tuple {
 
             fn tup_map(self, _: Func) -> Self::Output {}
         }
-        
+
         impl<Func> TupleAny<Func> for () {
             fn tup_any(self, _: Func) -> bool {
                 false
@@ -64,7 +64,7 @@ macro_rules! impl_tuple {
     };
     ($($T:ident)+) => {
         impl_tuple! { @rem $($T)* }
-        
+
         #[allow(non_snake_case)]
         impl<$($T,)+> Tuple for ($($T,)+) {}
 
@@ -81,7 +81,7 @@ macro_rules! impl_tuple {
                 )+)
             }
         }
-        
+
         #[allow(non_snake_case)]
         impl<Func $(, $T)+> TupleAny<Func> for ($($T,)+)
         where $(Func: TypeFunction<$T, Output = bool>),+  {
@@ -93,7 +93,7 @@ macro_rules! impl_tuple {
                         return true;
                     }
                 )+
-                
+
                 false
             }
         }
@@ -113,7 +113,7 @@ macro_rules! impl_tuple_zip {
     };
     ($($T:ident $U:ident)+) => {
         impl_tuple_zip! { @rem $($T $U)* }
-        
+
         #[allow(non_snake_case)]
         impl<Func $(, $T, $U)*> TupleZip<($($U,)*), Func> for ($($T,)*)
             where $(Func: TypeFunction<($T, $U)>),+

--- a/core/src/set/tuple.rs
+++ b/core/src/set/tuple.rs
@@ -1,4 +1,3 @@
-
 #[macro_export]
 macro_rules! type_function {
     (

--- a/core/tests/test_core.rs
+++ b/core/tests/test_core.rs
@@ -44,16 +44,14 @@ fn simple_test() {
 struct MyType<T> {
     x: u8,
     y: u8,
-    z: T
+    z: T,
 }
 
 #[test]
 pub fn generic_test() {
     impl<T> MyType_fields::z<MyType<T>> {
         pub fn pin(self) -> PinToPin<Self> {
-            unsafe {
-                PinToPin::new_unchecked(self)
-            }
+            unsafe { PinToPin::new_unchecked(self) }
         }
     }
 
@@ -62,11 +60,7 @@ pub fn generic_test() {
 
     use core::pin::Pin;
 
-    let my_type = MyType {
-        x: 0,
-        y: 1,
-        z: 3u8
-    };
+    let my_type = MyType { x: 0, y: 1, z: 3u8 };
 
     let my_type_pin = Pin::new(&my_type);
 
@@ -75,7 +69,7 @@ pub fn generic_test() {
     let my_type = MyType {
         x: 0,
         y: 1,
-        z: 3u32
+        z: 3u32,
     };
 
     let z = MyType::fields().z;
@@ -92,20 +86,14 @@ fn test_chain() {
         y: Bar {
             a: 1,
             b: 2,
-            c: Quaz {
-                q: (3, 4),
-                r: 5
-            }
+            c: Quaz { q: (3, 4), r: 5 },
         },
-        z: 6
+        z: 6,
     };
 
     let foo = Foo::fields();
     let bar = Bar::fields();
     let quaz = Quaz::fields();
 
-    assert_eq!(
-        *my_type.project_to(&foo.y.chain(bar.c).chain(quaz.r)),
-        5
-    );
+    assert_eq!(*my_type.project_to(&foo.y.chain(bar.c).chain(quaz.r)), 5);
 }

--- a/core/tests/test_core.rs
+++ b/core/tests/test_core.rs
@@ -71,7 +71,7 @@ pub fn generic_test() {
     let my_type_pin = Pin::new(&my_type);
 
     assert_eq!(*my_type_pin.project_to(z.pin()), 3);
-    
+
     let my_type = MyType {
         x: 0,
         y: 1,

--- a/core/tests/test_set.rs
+++ b/core/tests/test_set.rs
@@ -30,9 +30,7 @@ fn simple() {
     let FooFields { x, y, .. } = Foo::fields();
     let BarFields { a, .. } = Bar::fields();
 
-    let (x, y_a) = foo_ref.project_set_to((
-        x, y.chain(a)
-    ));
+    let (x, y_a) = foo_ref.project_set_to((x, y.chain(a)));
 
     *x = 1;
     *y_a = 10;
@@ -43,8 +41,8 @@ fn simple() {
 
 #[test]
 fn pin() {
-    use std::pin::Pin;
     use gfp_core::{PinToPin, PinToPtr};
+    use std::pin::Pin;
 
     let FooFields { x, y, .. } = Foo::fields();
     let BarFields { a, .. } = Bar::fields();
@@ -54,7 +52,7 @@ fn pin() {
 
     let (mut x, y_a) = foo_ref.project_set_to((
         unsafe { PinToPin::new_unchecked(x) },
-        PinToPtr::new(y.chain(a))
+        PinToPtr::new(y.chain(a)),
     ));
 
     *x = 1;

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -86,7 +86,7 @@ fn derive_named(ty: syn::DeriveInput) -> TokenStream {
             #[allow(non_camel_case_types)]
             pub struct #ident<T>(::gfp_core::derive::Invariant<T>);
         ));
-        
+
         contents.push(item!(
             impl<T> #ident<T> {
                 pub const INIT: Self = Self(::gfp_core::derive::Invariant(::gfp_core::derive::PhantomData));
@@ -104,7 +104,7 @@ fn derive_named(ty: syn::DeriveInput) -> TokenStream {
         ));
 
         let ty = &field.ty;
-        
+
         contents.push(item!(
             unsafe impl #generic_header ::gfp_core::Field for #ident<super::#input_ident #generic> {
                 type Parent = super::#input_ident #generic;
@@ -144,14 +144,14 @@ fn derive_named(ty: syn::DeriveInput) -> TokenStream {
             colon_token: field.colon_token,
             ty
         };
-        
+
         fields_marker.push(item);
     }
 
     let field_type_name = input_ident.append("Fields");
 
     TokenStream::from(quote! {
-        
+
         #[allow(non_snake_case)]
         #module
 
@@ -163,7 +163,7 @@ fn derive_named(ty: syn::DeriveInput) -> TokenStream {
             const FIELDS: #field_type_name #generic = #field_type_name {
                 #fields_new
             };
-            
+
             fn fields() -> #field_type_name #generic {
                 #field_type_name {
                     #fields_new
@@ -206,7 +206,7 @@ fn derive_unnamed(ty: syn::DeriveInput) -> TokenStream {
             #[allow(non_camel_case_types)]
             pub struct #ident<T>(::gfp_core::derive::Invariant<T>);
         ));
-        
+
         contents.push(item!(
             impl<T> #ident<T> {
                 pub const INIT: Self = Self(::gfp_core::derive::Invariant(::gfp_core::derive::PhantomData));
@@ -224,12 +224,12 @@ fn derive_unnamed(ty: syn::DeriveInput) -> TokenStream {
         ));
 
         let ty = &field.ty;
-        
+
         let index = syn::Member::Unnamed(syn::Index {
             index: i as u32,
             span: proc_macro2::Span::call_site()
         });
-        
+
         contents.push(item!(
             unsafe impl #generic_header ::gfp_core::Field for #ident<super::#input_ident #generic> {
                 type Parent = super::#input_ident #generic;
@@ -269,14 +269,14 @@ fn derive_unnamed(ty: syn::DeriveInput) -> TokenStream {
             colon_token: field.colon_token,
             ty
         };
-        
+
         fields_marker.push(item);
     }
 
     let field_type_name = input_ident.append("Fields");
 
     TokenStream::from(quote! {
-        
+
         #[allow(non_snake_case)]
         #module
 
@@ -284,7 +284,7 @@ fn derive_unnamed(ty: syn::DeriveInput) -> TokenStream {
 
         impl#generic_header #input_ident #generic #where_clause {
             const FIELDS: #field_type_name #generic = #field_type_name(#fields_new);
-            
+
             fn fields() -> #field_type_name #generic {
                 #field_type_name(#fields_new)
             }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,4 +1,3 @@
-
 extern crate proc_macro;
 
 use proc_macro_roids::*;
@@ -43,22 +42,38 @@ macro_rules! expr {
 
 fn derive_struct(ty: syn::DeriveInput) -> TokenStream {
     match ty.data {
-        syn::Data::Struct(syn::DataStruct { fields: syn::Fields::Named(_), .. }) => derive_named(ty),
-        syn::Data::Struct(syn::DataStruct { fields: syn::Fields::Unnamed(_), .. }) => derive_unnamed(ty),
-        syn::Data::Struct(syn::DataStruct { fields: syn::Fields::Unit, .. }) => {
-            syn::Error::new(ty.ident.span(), "Unit structs are not supported")
-                .to_compile_error().into()
-        },
-        _ => unreachable!()
+        syn::Data::Struct(syn::DataStruct {
+            fields: syn::Fields::Named(_),
+            ..
+        }) => derive_named(ty),
+        syn::Data::Struct(syn::DataStruct {
+            fields: syn::Fields::Unnamed(_),
+            ..
+        }) => derive_unnamed(ty),
+        syn::Data::Struct(syn::DataStruct {
+            fields: syn::Fields::Unit,
+            ..
+        }) => syn::Error::new(ty.ident.span(), "Unit structs are not supported")
+            .to_compile_error()
+            .into(),
+        _ => unreachable!(),
     }
 }
 
 fn derive_named(ty: syn::DeriveInput) -> TokenStream {
     let syn::DeriveInput {
-        attrs: _, vis, ident: input_ident, generics, data
+        attrs: _,
+        vis,
+        ident: input_ident,
+        generics,
+        data,
     } = ty;
 
-    let fields = if let syn::Data::Struct(syn::DataStruct { fields: syn::Fields::Named(fields), .. }) = data {
+    let fields = if let syn::Data::Struct(syn::DataStruct {
+        fields: syn::Fields::Named(fields),
+        ..
+    }) = data
+    {
         fields
     } else {
         unreachable!()
@@ -139,10 +154,12 @@ fn derive_named(ty: syn::DeriveInput) -> TokenStream {
 
         let item = syn::Field {
             attrs: Vec::new(),
-            vis: syn::Visibility::Public(syn::VisPublic { pub_token: syn::Token![pub](proc_macro2::Span::call_site()) }),
+            vis: syn::Visibility::Public(syn::VisPublic {
+                pub_token: syn::Token![pub](proc_macro2::Span::call_site()),
+            }),
             ident: Some(ident),
             colon_token: field.colon_token,
-            ty
+            ty,
         };
 
         fields_marker.push(item);
@@ -175,10 +192,18 @@ fn derive_named(ty: syn::DeriveInput) -> TokenStream {
 
 fn derive_unnamed(ty: syn::DeriveInput) -> TokenStream {
     let syn::DeriveInput {
-        attrs: _, vis, ident: input_ident, generics, data
+        attrs: _,
+        vis,
+        ident: input_ident,
+        generics,
+        data,
     } = ty;
 
-    let fields = if let syn::Data::Struct(syn::DataStruct { fields: syn::Fields::Unnamed(fields), .. }) = data {
+    let fields = if let syn::Data::Struct(syn::DataStruct {
+        fields: syn::Fields::Unnamed(fields),
+        ..
+    }) = data
+    {
         fields
     } else {
         unreachable!()
@@ -227,7 +252,7 @@ fn derive_unnamed(ty: syn::DeriveInput) -> TokenStream {
 
         let index = syn::Member::Unnamed(syn::Index {
             index: i as u32,
-            span: proc_macro2::Span::call_site()
+            span: proc_macro2::Span::call_site(),
         });
 
         contents.push(item!(
@@ -264,10 +289,12 @@ fn derive_unnamed(ty: syn::DeriveInput) -> TokenStream {
 
         let item = syn::Field {
             attrs: Vec::new(),
-            vis: syn::Visibility::Public(syn::VisPublic { pub_token: syn::Token![pub](proc_macro2::Span::call_site()) }),
+            vis: syn::Visibility::Public(syn::VisPublic {
+                pub_token: syn::Token![pub](proc_macro2::Span::call_site()),
+            }),
             ident: field.ident.clone(),
             colon_token: field.colon_token,
-            ty
+            ty,
         };
 
         fields_marker.push(item);
@@ -305,10 +332,10 @@ fn new_module(ident: syn::Ident) -> syn::ItemMod {
         ident,
         content: Some((
             syn::token::Brace {
-                span: proc_macro2::Span::call_site()
+                span: proc_macro2::Span::call_site(),
             },
-            Vec::new()
+            Vec::new(),
         )),
-        semi: None
+        semi: None,
     }
 }

--- a/derive/tests/simple.rs
+++ b/derive/tests/simple.rs
@@ -6,7 +6,7 @@ use gfp_derive::*;
 #[derive(Field)]
 struct Foo<T, U: Copy> {
     x: T,
-    y: U
+    y: U,
 }
 
 #[derive(Field)]
@@ -20,7 +20,7 @@ fn test() {
 
     let foo = Foo {
         x: Bar(0, 2.0),
-        y: 12
+        y: 12,
     };
 
     assert_eq!(*foo.project_to(field), 2.0);


### PR DESCRIPTION
This PR has two commits.  In the first, I hand wrapped a number of comment lines so that their maximum length was 80 characters.  I didn't do this to any code.

In the second commit, I used `cargo +nightly fmt --all` at the root of the crate to reformat the code.  This affected the code itself.